### PR TITLE
Bumps cryptonite upper bound

### DIFF
--- a/stripe-signature/stripe-signature.cabal
+++ b/stripe-signature/stripe-signature.cabal
@@ -39,7 +39,7 @@ library
         base >=4.10 && <4.15
       , base16-bytestring >= 0.1 && <0.2
       , bytestring >=0.10 && <0.11
-      , cryptonite >=0.25 && <0.27
+      , cryptonite >=0.25 && <0.28
       , memory >=0.14 && <0.16
       , stripe-concepts >=1.0 && <1.1
       , text >=1.2 && <1.3


### PR DESCRIPTION
Per commercialhaskell/stackage#5466, cryptonite-0.28 has been released with no breaking changes.

I haven't tested this locally since it _should_ be fine, but I can set up the project and try to build/test it if you'd prefer.